### PR TITLE
Turn repo into Python library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.eggs/
+.DS_Store
+.env/
+ENV/
+venv/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 iTunes Artwork Finder
 =====================
 
+This repository now includes a small Python package which provides a programmatic
+way to search the iTunes API for artwork URLs. The original JavaScript and PHP
+files are still present for reference.
+
+## Python usage
+
+Install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
+Then use it in your own code:
+
+```python
+from itunes_artwork_finder import search_artwork
+
+results = search_artwork("Ted Lasso", entity="tvSeason", country="us")
+for item in results:
+    print(item["title"], item["hires"])
+```
+
+## Web usage
+
 This is the JavaScript and PHP code that powers the iTunes Artwork Finder available at [https://bendodson.com/projects/itunes-artwork-finder/](https://bendodson.com/projects/itunes-artwork-finder/)
 
 To use on your own site, simply upload both the JavaScript and PHP files and then initialise the script with something like:

--- a/itunes_artwork_finder/__init__.py
+++ b/itunes_artwork_finder/__init__.py
@@ -1,0 +1,6 @@
+"""Python interface for retrieving iTunes artwork."""
+
+from .core import search_artwork
+
+__all__ = ["search_artwork"]
+__version__ = "0.1.0"

--- a/itunes_artwork_finder/__main__.py
+++ b/itunes_artwork_finder/__main__.py
@@ -1,0 +1,19 @@
+import argparse
+import json
+from .core import search_artwork
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Search iTunes artwork")
+    parser.add_argument("query", help="Search query")
+    parser.add_argument("--entity", default="tvSeason", help="iTunes entity")
+    parser.add_argument("--country", default="us", help="Country code")
+    parser.add_argument("--limit", type=int, default=25, help="Number of results")
+    args = parser.parse_args()
+
+    results = search_artwork(args.query, entity=args.entity, country=args.country, limit=args.limit)
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/itunes_artwork_finder/core.py
+++ b/itunes_artwork_finder/core.py
@@ -1,0 +1,99 @@
+import requests
+from urllib.parse import quote, urlparse
+
+__all__ = ["search_artwork"]
+
+SEARCH_URL = "https://itunes.apple.com/search"
+LOOKUP_URL = "https://itunes.apple.com/lookup"
+
+
+def _build_url(query: str, entity: str, country: str, limit: int) -> str:
+    short_film = False
+    e = entity
+    if entity == "shortFilm":
+        short_film = True
+        e = "movie"
+    if entity in {"id", "idAlbum"}:
+        return f"{LOOKUP_URL}?id={quote(query)}&country={country}"
+    url = f"{SEARCH_URL}?term={quote(query)}&country={country}&entity={e}&limit={limit}"
+    if short_film:
+        url += "&attribute=shortFilmTerm"
+    return url
+
+
+def _process_result(result: dict, entity: str) -> dict | None:
+    if entity == "id" and result.get("kind") != "feature-movie" and result.get("wrapperType") != "collection":
+        return None
+    if entity == "idAlbum" and result.get("collectionType") != "Album":
+        return None
+
+    width = height = 600
+    artwork_url = result.get("artworkUrl100")
+    if not artwork_url:
+        return None
+
+    data = {}
+    data["url"] = artwork_url.replace("100x100", "600x600")
+
+    hires = artwork_url.replace("100x100bb", "100000x100000-999")
+    parts = urlparse(hires)
+    hires = f"https://is5-ssl.mzstatic.com{parts.path}"
+
+    data["hires"] = hires
+
+    title = result.get("collectionName")
+    if entity in {"movie", "id", "shortFilm"}:
+        title = result.get("trackName") or result.get("collectionName")
+        width = 400
+    elif entity == "musicVideo":
+        title = f"{result.get('trackName')} (by {result.get('artistName')})"
+        width = 640
+        height = 464
+        data["url"] = hires
+    elif entity == "ebook":
+        title = f"{result.get('trackName')} (by {result.get('artistName')})"
+        width = 400
+    elif entity in {"album", "idAlbum"}:
+        title = f"{result.get('collectionName')} (by {result.get('artistName')})"
+    elif entity == "audiobook":
+        title = f"{result.get('collectionName')} (by {result.get('artistName')})"
+    elif entity == "podcast":
+        title = f"{result.get('collectionName')} (by {result.get('artistName')})"
+    elif entity in {"software", "iPadSoftware", "macSoftware"}:
+        data["url"] = artwork_url.replace("512x512bb", "1024x1024bb")
+        data["appstore"] = result.get("trackViewUrl")
+        title = result.get("trackName")
+        width = height = 512
+    elif entity == "tvSeason":
+        title = result.get("collectionName")
+    else:
+        title = result.get("collectionName")
+
+    if entity in {"album", "idAlbum"} and hires:
+        parts = hires.split("/image/thumb/")
+        if len(parts) == 2:
+            sub = parts[1].split("/")
+            sub.pop()
+            data["uncompressed"] = f"https://a5.mzstatic.com/us/r1000/0/{'/'.join(sub)}"
+
+    if not title:
+        return None
+    data["title"] = title
+    data["width"] = width
+    data["height"] = height
+    return data
+
+
+def search_artwork(query: str, entity: str = "tvSeason", country: str = "us", limit: int = 25) -> list[dict]:
+    """Search iTunes for artwork and return processed results."""
+    url = _build_url(query, entity, country, limit)
+    response = requests.get(url)
+    response.raise_for_status()
+    json_data = response.json()
+
+    results = []
+    for result in json_data.get("results", []):
+        item = _process_result(result, entity)
+        if item:
+            results.append(item)
+    return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "itunes-artwork-finder"
+version = "0.1.0"
+description = "Python library for retrieving iTunes artwork"
+authors = [{name = "Ben Dodson"}]
+readme = "README.md"
+license = {text = "Unlicense"}
+requires-python = ">=3.8"
+dependencies = ["requests"]
+
+[project.urls]
+Homepage = "https://github.com/bendodson/itunes-artwork-finder"
+
+[project.scripts]
+itunes-artwork-finder = "itunes_artwork_finder.__main__:main"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,10 @@
+from itunes_artwork_finder import search_artwork
+
+
+def test_search_movie():
+    results = search_artwork("The Matrix", entity="movie", limit=1)
+    assert isinstance(results, list)
+    assert results
+    first = results[0]
+    assert "title" in first
+    assert "url" in first


### PR DESCRIPTION
## Summary
- convert project into a Python package with `pyproject.toml`
- implement library code for fetching iTunes artwork
- add CLI entry point and tests
- update README with Python usage instructions
- ignore common build artifacts